### PR TITLE
Clean up in manager

### DIFF
--- a/src/kafka-one-to-n-exactly-once-executor.spec.ts
+++ b/src/kafka-one-to-n-exactly-once-executor.spec.ts
@@ -48,7 +48,7 @@ describe("KafkaOneToNExactlyOnceExecutor", () => {
   });
 
   afterEach(async () => {
-    await executor.cleanUp();
+    await manager.cleanUp();
 
     // Clean up topics we created
     const admin = manager.kafka.admin();

--- a/src/kafka-one-to-n-exactly-once-executor.ts
+++ b/src/kafka-one-to-n-exactly-once-executor.ts
@@ -40,10 +40,6 @@ export class KafkaOneToNExactlyOnceExecutor {
 
   private readonly logPrefix = KafkaOneToNExactlyOnceExecutor.name + ": ";
 
-  readonly cleanUp = async () => {
-    await this.manager.cleanUp();
-  };
-
   readonly init = async (): Promise<void> => {
     if (this.initialized) {
       const err = "already initialized";


### PR DESCRIPTION
Executor doesn't own the manager anymore, so it shouldn't call its cleanup method.